### PR TITLE
Fix vector ite compile with gcc

### DIFF
--- a/srcs/vector/ite.cpp
+++ b/srcs/vector/ite.cpp
@@ -45,7 +45,8 @@ int		main(void)
 	*(it -= 2) = 42;
 	*(it += 2) = 21;
 
-	std::cout << "const_ite +=/-=: " << *(ite += 2) << " | " << *(ite -= 2) << std::endl;
+	std::cout << "const_ite +=: " << *(ite += 2) << std::endl;
+	std::cout << "const_ite -=: " << *(ite -= 2) << std::endl;
 
 	std::cout << "(it == const_it): " << (ite == it) << std::endl;
 	std::cout << "(const_ite - it): " << (ite - it) << std::endl;


### PR DESCRIPTION
Hey, thank you for this awesome project!


`gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0` was throwing this error:

```
srcs/vector/ite.cpp:48:44: error: multiple unsequenced modifications to 'ite' [-Werror,-Wunsequenced]
        std::cout << "const_ite +=/-=: " << *(ite += 2) << " | " << *(ite -= 2) << std::endl;
                                                  ^                       ~~
```