### PR TITLE
[fix] max_size warning on Linux

### DIFF
--- a/fct.sh
+++ b/fct.sh
@@ -78,15 +78,15 @@ compare_output () {
 	if ! [ -s $1 ]; then
 		return 0
 	fi
-	regex=$(cat <<- EOF
-	\d+c\d+
-	< max_size: \d+
-	---
-	> max_size: \d+
-	EOF
-	)
+	regex="\d+c\d+\n< max_size: \d+\n---\n> max_size: \d+\n"
 
-	cat $1 | grep -v -Pzo "$regex" &>/dev/null
+	if [ `uname` == "Darwin" ]; then
+		grep_args="-vE"
+	else
+		grep_args="-vPzo"
+	fi
+
+	cat $1 | grep $grep_args "$regex" &> /dev/null
 	[ "$?" -eq "0" ] && return 1 || return 2;
 }
 

--- a/fct.sh
+++ b/fct.sh
@@ -86,7 +86,7 @@ compare_output () {
 	EOF
 	)
 
-	cat $1 | grep -v -E "$regex" &>/dev/null
+	cat $1 | grep -v -Pzo "$regex" &>/dev/null
 	[ "$?" -eq "0" ] && return 1 || return 2;
 }
 


### PR DESCRIPTION
Hi,
It seems that the warning on your tester depend on `grep` which haven't the same behavior on Mac and Linux. The value attribution to the variable `regex` could cause an issue too.

I then make a quick fix that's working on Linux (tested on mine and at 42 Paris), but I haven't the occasion to test it on Mac.

Could anybody confirm it's working on MacOS ?

Thanks

