### PR TITLE
Add test in vector/insert.cpp

### DIFF
--- a/srcs/vector/insert.cpp
+++ b/srcs/vector/insert.cpp
@@ -18,6 +18,7 @@ int		main(void)
 {
 	TESTED_NAMESPACE::vector<TESTED_TYPE> vct(10);
 	TESTED_NAMESPACE::vector<TESTED_TYPE> vct2;
+	TESTED_NAMESPACE::vector<TESTED_TYPE> vct3;
 
 	for (unsigned long int i = 0; i < vct.size(); ++i)
 		vct[i] = (vct.size() - i) * 3;
@@ -41,5 +42,11 @@ int		main(void)
 	printSize(vct2);
 
 	printSize(vct);
+
+	for (int i = 0; i < 5; ++i)
+		vct3.push_back(i);	
+	vct3.insert(vct3.begin() + 1, 2, 111);
+	printSize(vct3);
+
 	return (0);
 }

--- a/srcs/vector/insert.cpp
+++ b/srcs/vector/insert.cpp
@@ -44,7 +44,7 @@ int		main(void)
 	printSize(vct);
 
 	for (int i = 0; i < 5; ++i)
-		vct3.push_back(i);	
+		vct3.insert(vct3.end(), i);
 	vct3.insert(vct3.begin() + 1, 2, 111);
 	printSize(vct3);
 


### PR DESCRIPTION
I added a last test in the insert.cpp which handles this case ✌🏽:

If we insert and the number of elements that must be inserted are less than (end() - position) .
Of course we can only fit in this case if there is enough space in the vector.

The problem with this case is that, you may encounter overlapping if you don't do a backward copy or any technique to avoid this behaviour.